### PR TITLE
updating wgrib module version for rrfs

### DIFF
--- a/ecf/jgentracks_rrfs.ecf
+++ b/ecf/jgentracks_rrfs.ecf
@@ -22,9 +22,12 @@ module load cray-mpich/$cray_mpich_ver
 module load cray-pals/$cray_pals_ver
 module load libjpeg/$libjpeg_ver
 module load grib_util/$grib_util_ver
-module load wgrib2/$wgrib2_ver
-module load prod_envir/$prod_envir_ver
-module load prod_util/$prod_util_ver
+module load hdf5-D/$hdf5_ver
+module load netcdf-D/$netcdf_ver
+module load libaec/$libaec_ver
+module load g2c/$g2c_ver
+module load libjpeg-turbo/$libjpeg_turbo_ver
+module load wgrib2/$wgrib2_rrfs_ver
 
 module list
 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,12 +1,11 @@
 export gefs_ver=v12.3
 export gfs_ver=v16.3
-export rrfs_ver=v1.0
-export ukmet_ver=v2.2
-
 export naefs_ver=v7.0
 export sref_ver=v7.1
 export ens_tracker_ver=v1.3
 export nam_ver=v4.2
+export rrfs_ver=v1.0 #LO
+export ukmet_ver=v2.2 #LO
 
 export intel_ver=19.1.3.304
 export PrgEnv_intel_ver=8.1.0


### PR DESCRIPTION
NCO has added two versions of wgrib to the run.ver file—one that works for RRFS and another for the other models.