### PR TITLE
Adjusting ush script for the ECMWF file change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
+#Release Note: gentracks.v3.5.10 (2026/05/04)
+
+#This update prepares the package for the new ECMWF data format. In the operational DCD files, the 00-hour forecast ends with 0110, while all subsequent forecast hours end with 0010. The ush script has been adjusted to account for this minor file naming change.
+
+#1.ush/genesis_gettrk_poe.sh
+
+#-------------------------------------------------------------------------------------------------------##
 Official release notes:
 https://docs.google.com/document/d/1u7wzUJHO198-cp6Rt7I5hRgJ1eY6KUBRAdEzGGhO4LM/edit?tab=t.0

--- a/ush/genesis_gettrk_poe.sh
+++ b/ush/genesis_gettrk_poe.sh
@@ -2015,8 +2015,11 @@ if [ ${model} -eq 4 ] ; then
       let fhr=ict*6
       echo "fhr= $fhr  fhour= $fhour"
       fmmddhh=` ${NDATE} ${fhour} ${PDY}${CYL} | cut -c5- `
-      ec_hires_orig=DCD${immddhh}00${fmmddhh}00${ECMWF_FILE_EXT:-1}
-#      ec_hires_orig=ecens_DCD${immddhh}00${fmmddhh}001
+      if [ "${fhr}" -eq 0 ]; then
+        ec_hires_orig=DCD${immddhh}00${fmmddhh}01${ECMWF_FILE_EXT:-1}
+      else
+        ec_hires_orig=DCD${immddhh}00${fmmddhh}00${ECMWF_FILE_EXT:-1}
+      fi
 
       total_file_cnt=$(($total_file_cnt+1))
       if [ ! -s ${ecmwfdir}/${ec_hires_orig} ]


### PR DESCRIPTION
This update prepares the package for the new ECMWF data format. In the operational DCD files, the 00-hour forecast ends with 0110, while all subsequent forecast hours end with 0010. The ush script has been adjusted to account for this minor file naming change.
