### PR TITLE
Updating run script for GFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,55 @@
-*~
-.sw[a-p]
-.DS_Store
+# Compiled Object files
+**/.DS_Store
+*.slo
+*.lo
+*.o
+*.obj
+*.pyc
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.x
+*.out
+*.app
+
+**/cmake-build-debug
+**/CMakeCache.txt
+**/cmake_install.cmake
+**/install_manifest.txt
+**/CMakeFiles/
+**/CTestTestfile.cmake
+**/Makefile
+**/*.cbp
+**/CMakeScripts
+**/compile_commands.json
+
+include/divisible/*
+
+
+## Local 
+
+.idea/*.xml
+build/
+exec/
+include/*
+lib/*
+bin/*
+test/test_runner

--- a/RELEASE_NOTE_gentracks
+++ b/RELEASE_NOTE_gentracks
@@ -1,3 +1,8 @@
+**gentracks_v3.6.2**
+This release prepares the package to support GFS 0.25-degree grid data.
+However, the `ush` scripts convert the high-resolution data to 1-degree resolution, which allows the package to run within the 40-minute walltime.
+
+--------------------------------------------------------------------------------------
 **gentracks_v3.6.1**
 This release updates the `ush` script to accommodate RRFS new 2dfld file that includes surface U and V variables. 
 

--- a/dev/ecf/jgentracks_gfs.ecf
+++ b/dev/ecf/jgentracks_gfs.ecf
@@ -1,19 +1,25 @@
-#PBS -N gentracks_gfs_%CYC%
+#PBS -N gentracks_gfs
 #PBS -j oe
 #PBS -S /bin/bash
-#PBS -q %QUEUE%
+#PBS -q dev
 #PBS -l walltime=00:40:00
-#PBS -A %PROJ%-%PROJENVIR%
-#PBS -l select=1:ncpus=1:mem=4GB 
+#PBS -A ENSTRACK-DEV
+#PBS -l place=vscatter,select=2:ncpus=31:mpiprocs=31:mem=200GB 
 #PBS -l debug=true
 
 model=gentracks
-%include <head.h>
-%include <envir-p1.h>
+#%include <head.h>
+#%include <envir-p1.h>
 
 ##############################
 # Load modules
 ##############################
+module reset
+#export target=wcoss2
+source /lfs/h2/emc/ens/noscrub/hananeh.jafary/gentracks.v3.6.3/versions/run.ver
+#module load ${target}.lua
+module list
+
 module load intel/$intel_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
@@ -22,27 +28,34 @@ module load cray-pals/$cray_pals_ver
 module load libjpeg/$libjpeg_ver
 module load grib_util/$grib_util_ver
 module load wgrib2/$wgrib2_ver
+module load prod_util/2.0.13
 module list
 
 # EXPORT list here
 set -x
-export envir=%ENVIR%
+
 export cmodel=gfs
 export NETIN=gfs
 export RUN=gfs
-export cyc=%CYC%
+#export cyc=%CYC%
 
+export cyc=00
+export model=ens_tracker
+export envir=dev
+export KEEPDATA=YES
 
-${HOMEgentracks}/jobs/JTRACKER
+export DATAROOT=/lfs/h2/emc/ptmp/hananeh.jafary
+export HOMEgentracks=/lfs/h2/emc/ens/noscrub/hananeh.jafary/gentracks.v3.6.3
+${HOMEgentracks}/dev/jobs/JTRACKER
 
-if [ $? -ne 0 ]; then
-  ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
-  ecflow_client --abort
-  exit
-fi
+#if [ $? -ne 0 ]; then
+#  ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+#  ecflow_client --abort
+#  exit
+#fi
 
-%include <tail.h>
-%manual
+#%include <tail.h>
+#%manual
 ######################################################################
 PURPOSE:  To extract the storm tracks from gfs model forecasts.
 ######################################################################

--- a/dev/jobs/JTRACKER
+++ b/dev/jobs/JTRACKER
@@ -47,10 +47,10 @@ export CYC=$cyc
 # SENDCOM  - Copy Files From TMPDIR to $com
 # SENDDBN  - Send files to OSO
 ####################################
-export SENDECF=${SENDECF:-YES}
+export SENDECF=${SENDECF:-NO}
 export SENDCOM=${SENDCOM:-YES}
-export SENDDBN=${SENDDBN:-YES}
-export SENDOMB=${SENDOMB:-YES}
+export SENDDBN=${SENDDBN:-NO}
+export SENDOMB=${SENDOMB:-NO}
 
 ################################
 # Set up the HOME directory
@@ -68,7 +68,7 @@ export USHtrkr=$HOMEtracker/ush
 ##############################
 #setpdy.sh
 #. ./PDY
-export PDY=20260611
+export PDY=20260629
 
 ###############################################
 # Define COMIN and COMOUT directory
@@ -77,7 +77,7 @@ export PDY=20260611
 # COMIN for gfs, nam and arch
 #export namvitdir=$(compath.py ${envir}/nam/${nam_ver})
 #export rrfsvitdir=${namvitdir:-$(compath.py ${envir}/rrfs/${rrfs_ver})}
-export rrfsvitdir=/lfs/h1/ops/para/com/rrfs/v1.0/rrfs.${PDY}
+#export rrfsvitdir=/lfs/h1/ops/para/com/rrfs/v1.0/rrfs.${PDY}
 #export gfsvitdir=$(compath.py ${envir}/gfs/${gfs_ver})
 #export gfsvitdir=${gfsvitdir:-$(compath.py ${envir}/gfs/${gfs_ver})}
 #export archsyndir=${archsyndir:-$(compath.py ${envir}/gfs/${gfs_ver}/syndat)}
@@ -88,7 +88,7 @@ export archsyndir=/lfs/h1/ops/prod/com/gfs/v16.3/syndat
 #export COMGLTRK=${COMGLTRK:-$(compath.py -o ${NET}/${gentracks_ver}/${NET})}
 export COMGLTRK=/lfs/h2/emc/ptmp/hananeh.jafary/${NET}
 
-# output
+#output
 #export tmscrdir=${tmscrdir:-$(compath.py -o ${NET}/${gentracks_ver}/arch)}
 export tmscrdir=/lfs/h2/emc/ptmp/hananeh.jafary/arch
 
@@ -113,10 +113,12 @@ case $cmodel in
 	 export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
          ;;
    cmc)  export COMIN=${DCOMROOT}/$PDY/wgrbbul/cmc_gdps_25km
-	   export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
-         ;;
- gfs)  export COMIN=$(compath.py ${envir}/${cmodel}/${gfs_ver}/${RUN}.$PDY/$CYC/atmos)
 	 export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
+         ;;
+  gfs)  #export COMIN=$(compath.py ${envir}/${cmodel}/${gfs_ver}/${RUN}.$PDY/$CYC/atmos)
+       #export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
+        export COMIN=/lfs/h2/emc/gfstemp/emc.global/comroot/retrov17_01_realtime/gfs.${PDY}/00/products/atmos/grib2/0p25
+        export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/${RUN}.$PDY
          ;;
    nvgm) export COMIN=${DCOMROOT}/$RUN
 	   export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
@@ -124,10 +126,10 @@ case $cmodel in
  ukmet) export COMIN=$(compath.py ${envir}/${cmodel}/${ukmet_ver}/${RUN}.$PDY)
 	 export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
          ;;
-  rrfs)  # export COMIN=$(compath.py ${envir}/${cmodel}/${rrfs_ver}/${RUN}.$PDY/$CYC)
-	 # export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
-	 export COMIN=/lfs/h1/ops/para/com/rrfs/v1.0/rrfs.$PDY/$CYC
-	 export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/rrfs.$PDY
+  rrfs)  export COMIN=$(compath.py ${envir}/${cmodel}/${rrfs_ver}/${RUN}.$PDY/$CYC)
+	 export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
+#	 export COMIN=/lfs/h1/ops/para/com/rrfs/v1.0/rrfs.$PDY/$CYC
+#	 export COMOUT=/lfs/h2/emc/ptmp/hananeh.jafary/rrfs.$PDY
          ;;
    *)   export COMIN=$(compath.py ${envir}/${NETIN}/${cmodel}_ver/${RUN}.$PDY)
 	   export COMOUT=$(compath.py -o ${NET}/${gentracks_ver})/${RUN}.$PDY
@@ -141,7 +143,8 @@ module list
 ###########################################################
 #export COMOMB=${COMROOT}/omb/${envir}/tracker.${PDY}
 #export COMOUT_dailyTRK=${COMOUT_dailyTRK:-$(compath.py -o ${NET}/${gentracks_ver}/${NET}.$PDY)}
-export COMOUT_dailyTRK=/lfs/h2/emc/ptmp/hananeh.jafary/rrfs.$PDY
+#export COMOUT_dailyTRK=/lfs/h2/emc/ptmp/hananeh.jafary/rrfs.$PDY
+export COMOUT_dailyTRK=/lfs/h1/ops/prod/com/gentracks/v3.5/gentracks.$PDY
 # For future:  export COMOMB=${COMROOT}/gentracks/${envir}/gentracks.${PDY}
 
 mkdir -p $COMOUT $COMOUT_dailyTRK $COMGLTRK $tmscrdir

--- a/ecf/jgentracks_gfs.ecf
+++ b/ecf/jgentracks_gfs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -l walltime=00:40:00
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l select=1:ncpus=1:mem=4GB 
+#PBS -l place=vscatter,select=2:ncpus=31:mpiprocs=31:mem=200GB  
 #PBS -l debug=true
 
 model=gentracks

--- a/ush/genesis_gettrk_poe.sh
+++ b/ush/genesis_gettrk_poe.sh
@@ -1654,7 +1654,7 @@ then
 
         if [ -s ${globaldir}/${globalgfile}${fhour}.grib2 ]
         then
-          echo ${globaldir}/${globalgfile}${fhour},grib2
+          echo ${globaldir}/${globalgfile}${fhour}.grib2
           # Try to wgrib the primary file....
           $WGRIB2 -s ${globaldir}/${globalgfile}${fhour}.grib2 > globalgfile.ix
           gfile=${globaldir}/${globalgfile}${fhour}.grib2

--- a/ush/genesis_gettrk_poe.sh
+++ b/ush/genesis_gettrk_poe.sh
@@ -110,8 +110,8 @@ export maxtime=65    # Max number of forecast time levels
                    99  99  99  99  99  99  99  99  99  99
                    99  99  99  99  99  99  99  99  99  99' 
        else
-         globalgfile=gfs.t${CYL}z.pgrb2.1p00.f
-         globaligfile=gfs.t${CYL}z.pgrb2.1p00.f
+         globalgfile=gfs.t${CYL}z.pres_a.0p25.f
+         globaligfile=gfs.t${CYL}z.pres_a.0p25.f
          fcsthrs=' 000 006 012 018 024 030 036 042 048 054 
                    060 066 072 078 084 090 096 102 108 114
                    120 126 132 138 144
@@ -1652,12 +1652,12 @@ then
 
       else
 
-        if [ -s ${globaldir}/${globalgfile}${fhour} ]
+        if [ -s ${globaldir}/${globalgfile}${fhour}.grib2 ]
         then
-          echo ${globaldir}/${globalgfile}${fhour}
+          echo ${globaldir}/${globalgfile}${fhour},grib2
           # Try to wgrib the primary file....
-          $WGRIB2 -s ${globaldir}/${globalgfile}${fhour} > globalgfile.ix
-          gfile=${globaldir}/${globalgfile}${fhour}
+          $WGRIB2 -s ${globaldir}/${globalgfile}${fhour}.grib2 > globalgfile.ix
+          gfile=${globaldir}/${globalgfile}${fhour}.grib2
         else
             set +x
             echo " "
@@ -1668,7 +1668,7 @@ then
             echo " !!! symdh=  ${symdh}                                 !!!!!!!!!!!!!!"
             echo " !!! fhour=  ${fhour}                                 !!!!!!!!!!!!!!"
             echo " !!! Check for the existence of these files:          !!!!!!!!!!!!!!"
-            echo " !!!    ${globaldir}/${globalgfile}${fhour} "
+            echo " !!!    ${globaldir}/${globalgfile}${fhour}.grib2 "
             echo " !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
             echo " "
             set -x
@@ -1700,9 +1700,16 @@ then
         echo "Timing: fhour= $fhour after wgrib loop at `date`"
         set -x
 
-        global_master_file=${PERTDATA}/master.globalgribfile.${PDY}${CYL}.f${fhour}
+	${WGRIB2} ${PERTDATA}/master.globalgribfile.${PDY}${CYL}.f${fhour} \
+	  -set_grib_type same -set_bitmap 1 \
+          -new_grid_winds earth \
+	  -new_grid latlon 0:360:1.0 90:181:-1.0 \
+          gfslatlon.pgrb.${PDY}${CYL}.f0${fhour}
 
-          cat ${global_master_file} >> ${PERTDATA}/globalgribfile.${PDY}${CYL}
+
+        global_master_file=${PERTDATA}/gfslatlon.pgrb.${PDY}${CYL}.f0${fhour}
+
+        cat ${global_master_file} >> ${PERTDATA}/globalgribfile.${PDY}${CYL}
 
       fi
   


### PR DESCRIPTION
This is a resubmission of the gentracks.v.3.6.2. 
This version uses GFS 0p25 files instead 1 degree. However, it converts 0p25 to 1 degree to meet the operational run walltime. 